### PR TITLE
Update install and upgrade docs

### DIFF
--- a/docs/content/docs/upgrading.md
+++ b/docs/content/docs/upgrading.md
@@ -39,10 +39,10 @@ git fetch upstream
 git tag
 # Checkout the version you wish to use
 # Check the output fof the available version tags
-git checkout upstream/v2.2.0 -b v2.2.0
-git checkout origin/main
-# Merge the latest changes from upstream into your curren branch
-git merge v2.2.0
+git checkout tags/v2.3.0 -b v2.3.0
+git checkout main
+# Merge the latest changes from upstream into your current branch
+git merge v2.3.0
 # Push the merged changes to your CodeCommit
 git push origin
 ```

--- a/docs/static/js/quick-start.js
+++ b/docs/static/js/quick-start.js
@@ -218,8 +218,6 @@ function handleForm(event) {
 	appendStep("Fetch available tags", "git fetch --all --tags");
 	appendStep("View tags", "git tag");
 	appendStep("Checkout tag", `git checkout tags/${data.sourceGitTag}`);
-	appendStep("Delete existing main branch", "git branch -d main");
-	appendStep("Checkout new main branch", "git checkout -b main");
 
 	appendSection("Push source code to your CodeCommit");
 	appendStep(
@@ -234,7 +232,7 @@ function handleForm(event) {
 		"Add CodeCommit as a remote",
 		`git remote add codecommit https://git-codecommit.\${AWS_REGION}.amazonaws.com/v1/repos/${data.sourceGitRepo}`
 	);
-	appendStep("Push files", `git push codecommit ${data.sourceGitBranch}`);
+	appendStep("Push files", `git push codecommit ${data.sourceGitTag}:${data.sourceGitBranch}`);
 
 	appendSection("Deploy the pipeline ");
 	appendStep(

--- a/docs/static/js/quick-start.js
+++ b/docs/static/js/quick-start.js
@@ -218,6 +218,8 @@ function handleForm(event) {
 	appendStep("Fetch available tags", "git fetch --all --tags");
 	appendStep("View tags", "git tag");
 	appendStep("Checkout tag", `git checkout tags/${data.sourceGitTag}`);
+	appendStep("Delete existing main branch", "git branch -d main");
+	appendStep("Checkout new main branch", "git checkout -b main");
 
 	appendSection("Push source code to your CodeCommit");
 	appendStep(


### PR DESCRIPTION
*Issue #, if available:*

N/A

*Description of changes:*

1. Update installation instructions as without deleting and re-creating main branch the tag is not deployed

git checkout tags/v2.3.0 # Checkout tag

This command checks out the tag but doesn't reset main branch to be at this tag

2. Update upgrade instructions as:-

git checkout upstream/v2.2.0 -b v2.2.0 is not valid
git checkout origin/main results in a detached head state rather than checking out main

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
