### PR TITLE
Wrap require in try/catch statement to avoid error when readable is not enabled

### DIFF
--- a/website/src/page/readable/hooks/useReadableSubscription.tsx
+++ b/website/src/page/readable/hooks/useReadableSubscription.tsx
@@ -23,12 +23,12 @@ let subscription_readableUpdateJobItem: string;
 let readableGetJob: string;
 
 try {
-  if (features.readable) {
-    subscription_readableUpdateJobItem = require("../../../graphql/subscriptions").readableUpdateJobItem;
-    readableGetJob = require("../../../graphql/queries").readableGetJob;
-  }
+	if (features.readable) {
+		subscription_readableUpdateJobItem = require("../../../graphql/subscriptions").readableUpdateJobItem;
+		readableGetJob = require("../../../graphql/queries").readableGetJob;
+	}
 } catch (error) {
-  // Ignore the error and continue
+	// Ignore the error and continue
 }
 
 export const UseReadableSubscription = (

--- a/website/src/page/readable/hooks/useReadableSubscription.tsx
+++ b/website/src/page/readable/hooks/useReadableSubscription.tsx
@@ -22,10 +22,13 @@ const features = require("../../../features.json");
 let subscription_readableUpdateJobItem: string;
 let readableGetJob: string;
 
-if (features.readable) {
-	subscription_readableUpdateJobItem =
-		require("../../../graphql/subscriptions").readableUpdateJobItem;
-	readableGetJob = require("../../../graphql/queries").readableGetJob;
+try {
+  if (features.readable) {
+    subscription_readableUpdateJobItem = require("../../../graphql/subscriptions").readableUpdateJobItem;
+    readableGetJob = require("../../../graphql/queries").readableGetJob;
+  }
+} catch (error) {
+  // Ignore the error and continue
 }
 
 export const UseReadableSubscription = (


### PR DESCRIPTION
*Issue #, if available:*

N/A

*Description of changes:*

This change wrapped a require in a try/catch statement as otherwise the build fails when readable is not enabled

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
