### PR TITLE
Fix privaterepo noapproval

### DIFF
--- a/util/getOptions/README.md
+++ b/util/getOptions/README.md
@@ -1,0 +1,16 @@
+# README
+
+The getOptions runs in the CodePipeline to pull the SSM Parameter Store config and generate a config.json. The config.json is then used aas an input into the CDK deployment. This util can be run directly.
+
+To pull the correct SSM Parameter Store values we must set the `INSTANCE_NAME` that is used in the prefix. By default this is `main`. 
+
+```
+export INSTANCE_NAME="main"
+npm run start
+```
+
+The CodePipeline synth step copies the result of this util into the CDK working directory (/infrastructure).
+
+```sh
+cp ./config.json ../../infrastructure/config.json && cat ../../infrastructure/config.json
+```

--- a/util/getOptions/flake.nix
+++ b/util/getOptions/flake.nix
@@ -12,7 +12,19 @@
 		devShells.x86_64-linux.default = pkgs.mkShell {
 			packages = with pkgs; [
 				nodejs_22
+				# Optional
+				bat
+				jq
 			];
+			shellHook = ''
+			echo ""
+			echo "package.json scripts"
+			echo ""
+			cat package.json | jq .scripts
+			echo ""
+			bat --style=plain --paging=never ./README.md
+			echo ""
+			''; 
 		};
 	};
 }

--- a/util/installer/README.md
+++ b/util/installer/README.md
@@ -1,0 +1,35 @@
+# README
+
+The installer util can be run directly or in steps. Previx these actions with `npm run`.
+
+```
+npm run wizard
+```
+
+## Actions
+
+- `wizard`: Runs all parts of the wizard
+
+The wizard is broken into steps run in this specific order. 
+
+1. `awsconfig`: Gets the AWS config details (E.g. Account ID, Region ID)
+2. `options`: Gets the options from the user via interactive CLI
+3. `prereq`: Performs preqrequisites (E.g. Enable Macie)
+4. `parameters`: Pushes options into parameter store
+5. `deploy`: Runs CDK deployment
+6. `monitor`: Monitors CodePipeline
+
+For quickly testing manual config changes the parameters and deploy steps can be run with this:
+
+- `parameters_deploy`: combines `parameters` & `deploy` from above
+
+## config.json
+A config.json file is created by the installer into the /infrastructure directory. When calling the actions individually this file will need to be copied to the working directory. You can then edit the config.json for quick edits.
+
+```sh
+$ pwd
+/home/philipws/src/document-translation/util/installer
+cp ../../infrastructure/config.json config.json
+```
+
+When using the wizard action the json data is passed through the script so no config.json is used. This only applies when being called directly.

--- a/util/installer/flake.nix
+++ b/util/installer/flake.nix
@@ -14,8 +14,17 @@
 				nodejs_22
 				# Optional
 				bat
+				jq
 			];
-			shellHook = ''bat --style=plain --paging=never ./README.md''; 
+			shellHook = ''
+			echo ""
+			echo "package.json scripts"
+			echo ""
+			cat package.json | jq .scripts
+			echo ""
+			bat --style=plain --paging=never ./README.md
+			echo ""
+			''; 
 		};
 	};
 }

--- a/util/installer/src/parameters.ts
+++ b/util/installer/src/parameters.ts
@@ -29,7 +29,7 @@ export const saveConfigToParameterStore = async (config: Config) => {
 	const overwrite = true;
 	const prefix = `/doctran/${config.common.instance.name}/`;
 	for (const [key, value] of Object.entries(flattenedConfig)) {
-		if (value) {
+		if (value !== undefined && value !== null && value.toString().length > 0) {
 			await putParameter(prefix, key, value.toString(), overwrite);
 			// calculate 1 second plus up to 1 second of jitter
 			const oneSecond = 1000;


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

The installer did not overwrite SSM Parameter Store values if the new value was `false`. This resulted in the new config not applying when run in the pipeline as it constructs the config.json from the values in SSM Parameter Store. For the most part this was not a problem as the default of no value was also `false`. However, the default value for a pipeline manual approval is `true` instead. 

Now the installer saves values of `false` to SSM Parameter Store. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
