### PR TITLE
updated installer options to fix cognito preferences error

### DIFF
--- a/util/installer/src/options.ts
+++ b/util/installer/src/options.ts
@@ -35,11 +35,11 @@ const mapConfig = (options: ConfigurationOptions): Config => {
 			cognito: {
 				localUsers: {
 					enable: options.appCognitoOptions.app.cognito.localUsers.enable,
-					mfa: options.appCognitoLocalOptions.app.cognito.localUsers.mfa,
+					mfa: options.appCognitoOptions.app.cognito.localUsers.enable ? options.appCognitoLocalOptions.app.cognito.localUsers.mfa : {},
 				},
 				saml: {
 					enable: options.appCognitoOptions.app.cognito.saml.enable,
-					metadataUrl: options.appCognitoOptions.app.cognito.saml.metadataUrl,
+					metadataUrl: options.appCognitoOptions.app.cognito.saml.enable ? options.appCognitoSamlOptions.app.cognito.saml.metadataUrl : undefined,
 				},
 			},
 			webUi: options.appWebOptions.app.webUi,


### PR DESCRIPTION
*Issue #, if available:*
90
*Description of changes:*
Updated options file to add default values for local mfa and saml metadataUrl if they are not enabled by the user.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
