### PR TITLE
Add VSCode extensions recommendations for Prettier

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,5 @@
+{
+    "recommendations": [
+        "esbenp.prettier-vscode"
+    ]
+}


### PR DESCRIPTION
I added the `.vscode/extensions.json` file to provide recommendations for workspace extensions. Since it is configured to use Prettier to format the code, I think it's a good idea to inform users about this extension, especially if they haven't already installed it in their code editor.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
